### PR TITLE
Using topic.RawSchema value for SchemaResgitry Api call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/labstack/echo/v4 v4.9.0
 	github.com/mattn/go-sqlite3 v1.14.15
+	github.com/sijms/go-ora/v2 v2.7.16
 	github.com/spf13/viper v1.13.0
 	go.uber.org/zap v1.23.0
 )
@@ -55,7 +56,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
-	github.com/sijms/go-ora/v2 v2.7.16 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/kafkalistener/kafkalistener.go
+++ b/kafkalistener/kafkalistener.go
@@ -1,9 +1,11 @@
 package kafkalistener
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"log"
 	"os"
@@ -132,9 +134,15 @@ func (mb *MessageBroker) Publish(topic *Topic, data interface{}) error {
 		return ErrPublishOnConsumeOnly
 	}
 	schemaIdBytes := make([]byte, 4)
-	id, _, err = mb.registryClient.IsRegistered(topic.Name+"-value", topic.Schema.String())
+
+	compactSchema, err := compactSchema(topic.RawSchema)
+	if err == nil {
+		return err
+	}
+
+	id, _, err = mb.registryClient.IsRegistered(topic.Name+"-value", compactSchema)
 	if err != nil {
-		id, _, err = mb.registryClient.CreateSchema(topic.Name+"-value", topic.Schema.String())
+		id, _, err = mb.registryClient.CreateSchema(topic.Name+"-value", compactSchema)
 		if err != nil {
 			return err
 		}
@@ -198,4 +206,16 @@ func configurePublisher(
 	}
 
 	return kafka.NewPublisher(publisherConfig, logger)
+}
+
+func compactSchema(schema string) (string, error) {
+	var err error
+	var str string
+	cmpSchema := &bytes.Buffer{}
+	err = json.Compact(cmpSchema, []byte(schema))
+	if err != nil {
+		return "", err
+	}
+	str = cmpSchema.String()
+	return str, nil
 }

--- a/kafkalistener/kafkalistener.go
+++ b/kafkalistener/kafkalistener.go
@@ -136,7 +136,7 @@ func (mb *MessageBroker) Publish(topic *Topic, data interface{}) error {
 	schemaIdBytes := make([]byte, 4)
 
 	compactSchema, err := compactSchema(topic.RawSchema)
-	if err == nil {
+	if err != nil {
 		return err
 	}
 

--- a/kafkalistener/kafkalistener_test.go
+++ b/kafkalistener/kafkalistener_test.go
@@ -1,0 +1,64 @@
+package kafkalistener
+
+import (
+	"testing"
+)
+
+func TestCompactSchema(t *testing.T) {
+	var err error
+	var RawSchema, CmpSchema string
+
+	RawSchema = `
+		{
+			"type": "record",
+			"name": "ConnectDefault",
+			"namespace": "io.confluent.connect.avro",
+			"fields": [
+				 {
+						"name": "ULTRACLUB_ID",
+						"type": "long"
+				 },
+				 {
+						"name": "CURRENT_TIER",
+						"type": [
+							 "null",
+							 "string"
+						],
+						"default": null
+				 },
+				 {
+						"name": "UPCOMING_TIER",
+						"type": [
+							 "null",
+							 "string"
+						],
+						"default": null
+				 },
+				 {
+						"name": "UPDATE_DATE",
+						"type": [
+							 "null",
+							 {
+									"type": "long",
+									"connect.version": 1,
+									"connect.name": "org.apache.kafka.connect.data.Timestamp",
+									"logicalType": "timestamp-millis"
+							 }
+						],
+						"default": null
+				 	}
+				]
+	 		}
+		`
+
+	CmpSchema = `{"type":"record","name":"ConnectDefault","namespace":"io.confluent.connect.avro","fields":[{"name":"ULTRACLUB_ID","type":"long"},{"name":"CURRENT_TIER","type":["null","string"],"default":null},{"name":"UPCOMING_TIER","type":["null","string"],"default":null},{"name":"UPDATE_DATE","type":["null",{"type":"long","connect.version":1,"connect.name":"org.apache.kafka.connect.data.Timestamp","logicalType":"timestamp-millis"}],"default":null}]}`
+
+	schema, err := compactSchema(RawSchema)
+	if err != nil {
+		t.Errorf("error = %v", err)
+	}
+	if schema != CmpSchema {
+		t.Errorf("Strings not equal = %v", schema)
+	}
+
+}


### PR DESCRIPTION
When verifying if a schema exists on schema registry, the function was using the string result from topic.Schema.String() but this value was not the same as the value of topic.RawSchema. This caused that that the topic could not be identified correctly since the resulting value from topic.Schema.String() did not match with what was in Schema Registry.

This fix sends the compact json value of topic.RawSchema to properly verify that the schema exists on Schema Registry.