### PR TITLE
Enhance Kafka queue implementation with memory size limits and fetch …

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "snyk.advanced.autoSelectOrganization": true
+}

--- a/kafkalistener/kafkalistener.go
+++ b/kafkalistener/kafkalistener.go
@@ -187,6 +187,13 @@ func setSaramaConfig(tlsConfig *tls.Config) *sarama.Config {
 	saramaConfig.Net.MaxOpenRequests = 1
 	saramaConfig.Producer.Idempotent = true
 
+	// Fix 1: cap per-partition consumer channel buffer (default 256) to limit in-process message accumulation
+	saramaConfig.ChannelBufferSize = 64
+
+	// Fix 4: bound fetch sizes to prevent a single broker response from consuming hundreds of MB
+	saramaConfig.Consumer.Fetch.Default = 1 * 1024 * 1024 // 1 MB per fetch request
+	saramaConfig.Consumer.Fetch.Max = 10 * 1024 * 1024    // 10 MB hard cap per fetch request
+
 	return saramaConfig
 }
 
@@ -201,7 +208,21 @@ func (mb *MessageBroker) SetConsumerMaxWaitTime(waitms int) {
 func (mb *MessageBroker) SetConsumerMinBytes(bytes int32) {
 	saramaConfig := mb.subscriberConfig.OverwriteSaramaConfig
 	saramaConfig.Consumer.Fetch.Min = bytes
+}
 
+// SetChannelBufferSize overrides the per-partition Sarama channel buffer (default 64).
+func (mb *MessageBroker) SetChannelBufferSize(size int) {
+	mb.subscriberConfig.OverwriteSaramaConfig.ChannelBufferSize = size
+}
+
+// SetConsumerFetchDefault overrides the default fetch request size in bytes.
+func (mb *MessageBroker) SetConsumerFetchDefault(bytes int32) {
+	mb.subscriberConfig.OverwriteSaramaConfig.Consumer.Fetch.Default = bytes
+}
+
+// SetConsumerFetchMax overrides the maximum fetch request size in bytes.
+func (mb *MessageBroker) SetConsumerFetchMax(bytes int32) {
+	mb.subscriberConfig.OverwriteSaramaConfig.Consumer.Fetch.Max = bytes
 }
 
 func configurePublisher(

--- a/kafkaqueue/hybridqueue.go
+++ b/kafkaqueue/hybridqueue.go
@@ -11,20 +11,23 @@ import (
 // HybridQueue provides a queue that uses Redis as primary storage
 // and falls back to in-memory queue when Redis is unavailable.
 type HybridQueue struct {
-	redisQueue  *RedisQueue
-	memoryQueue *MemoryQueue
-	useMemory   atomic.Bool
-	mu          sync.RWMutex
+	redisQueue    *RedisQueue
+	memoryQueue   *MemoryQueue
+	useMemory     atomic.Bool
+	mu            sync.RWMutex
+	maxMemorySize int
 
 	healthCheckInterval time.Duration
 	stopHealthCheck     chan struct{}
 }
 
 // NewHybridQueue creates a new hybrid queue with Redis as primary and memory as fallback.
-func NewHybridQueue(redisQueue *RedisQueue) *HybridQueue {
+// maxMemorySize caps the in-memory fallback queue; use 0 for unbounded (not recommended).
+func NewHybridQueue(redisQueue *RedisQueue, maxMemorySize int) *HybridQueue {
 	hq := &HybridQueue{
 		redisQueue:          redisQueue,
-		memoryQueue:         NewMemoryQueue(),
+		memoryQueue:         NewMemoryQueue(maxMemorySize),
+		maxMemorySize:       maxMemorySize,
 		healthCheckInterval: 10 * time.Second,
 		stopHealthCheck:     make(chan struct{}),
 	}

--- a/kafkaqueue/memoryqueue.go
+++ b/kafkaqueue/memoryqueue.go
@@ -2,30 +2,37 @@ package kafkaqueue
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 )
 
-// MemoryQueue provides an unbounded in-memory queue with buffering.
+// ErrQueueFull is returned by Push when the queue has reached its maximum size.
+var ErrQueueFull = errors.New("queue is full")
+
+// MemoryQueue provides a bounded in-memory queue with buffering.
 type MemoryQueue struct {
-	in     chan interface{}
-	out    chan interface{}
-	buffer []interface{}
-	mu     sync.RWMutex
-	closed bool
+	in      chan interface{}
+	out     chan interface{}
+	buffer  []interface{}
+	mu      sync.RWMutex
+	closed  bool
+	maxSize int
 }
 
-// NewMemoryQueue creates a new in-memory queue with initial capacity of 1000.
-func NewMemoryQueue() *MemoryQueue {
-	const initCapacity = 1000
+// NewMemoryQueue creates a new in-memory queue capped at maxSize items.
+// maxSize <= 0 means unbounded (not recommended in production).
+func NewMemoryQueue(maxSize int) *MemoryQueue {
+	const initCapacity = 256
 
 	in := make(chan interface{}, initCapacity)
 	out := make(chan interface{}, initCapacity)
 
 	mq := &MemoryQueue{
-		in:     in,
-		out:    out,
-		buffer: make([]interface{}, 0, initCapacity),
+		in:      in,
+		out:     out,
+		buffer:  make([]interface{}, 0, initCapacity),
+		maxSize: maxSize,
 	}
 
 	go mq.runBuffer(initCapacity)
@@ -92,7 +99,7 @@ loop:
 	mq.mu.Unlock()
 }
 
-// Push adds a message to the memory queue.
+// Push adds a message to the memory queue. Returns ErrQueueFull when at capacity.
 func (mq *MemoryQueue) Push(_ context.Context, q Queue) error {
 	mq.mu.RLock()
 	if mq.closed {
@@ -100,6 +107,10 @@ func (mq *MemoryQueue) Push(_ context.Context, q Queue) error {
 		return nil
 	}
 	mq.mu.RUnlock()
+
+	if mq.maxSize > 0 && mq.Len() >= mq.maxSize {
+		return ErrQueueFull
+	}
 
 	mq.in <- q
 	return nil
@@ -133,11 +144,11 @@ func (mq *MemoryQueue) TryPop() (*Queue, bool) {
 	}
 }
 
-// Len returns the approximate length of the queue.
+// Len returns the approximate total number of items across all internal buffers.
 func (mq *MemoryQueue) Len() int {
 	mq.mu.RLock()
 	defer mq.mu.RUnlock()
-	return len(mq.buffer) + len(mq.out)
+	return len(mq.buffer) + len(mq.out) + len(mq.in)
 }
 
 // Close closes the memory queue.


### PR DESCRIPTION
…size bounds

- Introduced maxMemorySize parameter in HybridQueue to cap in-memory queue size.
- Updated NewMemoryQueue to accept maxSize, enforcing bounded memory usage.
- Added error handling for full memory queue in Push method.
- Set fetch request size limits in Sarama configuration to optimize memory usage.