### PR TITLE
Add support for Kafka static group membership and session timeout con…

### DIFF
--- a/kafkalistener/entities.go
+++ b/kafkalistener/entities.go
@@ -1,6 +1,8 @@
 package kafkalistener
 
 import (
+	"time"
+
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill-kafka/v3/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -18,6 +20,17 @@ type KafkaConfig struct {
 	SchemaReg       string   `yaml:"schema_registration"`
 	Brokers         []string `yaml:"brokers"`
 	TLS             tls.TLS  `yaml:"TLS"`
+	// GroupInstanceID enables Kafka static group membership (KIP-345).
+	// Must be stable across restarts and unique per replica (e.g. K8s StatefulSet pod name).
+	// When set, the broker skips rebalancing if the pod restarts within SessionTimeout.
+	// Leave empty to disable.
+	GroupInstanceID string `yaml:"group_instance_id"`
+	// SessionTimeout is how long the broker waits for a heartbeat before declaring the
+	// consumer dead and triggering a rebalance. Defaults to 45s when unset.
+	// With static membership, this doubles as the OOMKill-restart window — set it to
+	// comfortably exceed your worst-case pod restart time.
+	// Heartbeat interval is automatically set to SessionTimeout/3.
+	SessionTimeout time.Duration `yaml:"session_timeout"`
 }
 
 type MessageBroker struct {

--- a/kafkalistener/kafkalistener.go
+++ b/kafkalistener/kafkalistener.go
@@ -42,7 +42,7 @@ func New(
 		return nil, err
 	}
 
-	saramaConfig := setSaramaConfig(tlsConfig)
+	saramaConfig := setSaramaConfig(config, tlsConfig)
 	watermillLogger := watermill.NewStdLoggerWithOut(os.Stdout, debug, debug)
 
 	publisher, err = configurePublisher(config, saramaConfig, watermillLogger)
@@ -66,7 +66,7 @@ func New(
 		ReconnectRetrySleep:   time.Second * 60,
 	}
 
-	routerConfig := message.RouterConfig{}
+	routerConfig := message.RouterConfig{CloseTimeout: 20 * time.Second}
 	router, err := message.NewRouter(routerConfig, watermillLogger)
 	if err != nil {
 		log.Println("Error creating router: ", err)
@@ -169,15 +169,31 @@ func GetRegistryClient(tlsConfig *tls.Config, schemaReg string) (*registry.Clien
 	return registry.NewClient(schemaReg, registry.WithHTTPClient(httpsClient))
 }
 
-func setSaramaConfig(tlsConfig *tls.Config) *sarama.Config {
+func setSaramaConfig(config *KafkaConfig, tlsConfig *tls.Config) *sarama.Config {
 	saramaConfig := kafka.DefaultSaramaSubscriberConfig()
 
 	saramaConfig.Net.TLS.Config = tlsConfig
 	saramaConfig.Net.TLS.Enable = true
 	saramaConfig.Version = sarama.V4_1_0_0
-	saramaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
 	saramaConfig.Metadata.RefreshFrequency = time.Second * 30
 	saramaConfig.Metadata.Timeout = time.Minute * 1
+
+	if config.FromOldest {
+		saramaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
+	} else {
+		saramaConfig.Consumer.Offsets.Initial = sarama.OffsetNewest
+	}
+
+	if config.GroupInstanceID != "" {
+		saramaConfig.Consumer.Group.InstanceId = config.GroupInstanceID
+	}
+
+	sessionTimeout := config.SessionTimeout
+	if sessionTimeout == 0 {
+		sessionTimeout = 45 * time.Second
+	}
+	saramaConfig.Consumer.Group.Session.Timeout = sessionTimeout
+	saramaConfig.Consumer.Group.Heartbeat.Interval = sessionTimeout / 3
 
 	// Producer tweaks
 	saramaConfig.Producer.Return.Successes = true


### PR DESCRIPTION
This pull request enhances the Kafka listener's configuration flexibility and reliability by introducing support for static group membership and configurable session timeouts, as well as improving router and Sarama client configuration. The main changes are grouped below:

Kafka static group membership and session timeout support:

* Added `GroupInstanceID` and `SessionTimeout` fields to the `KafkaConfig` struct in `entities.go`, enabling static group membership (KIP-345) and allowing the session timeout to be configured per deployment. This helps prevent unnecessary rebalancing during pod restarts and allows tuning for Kubernetes environments.
* Updated `setSaramaConfig` to set `Consumer.Group.InstanceId`, `Consumer.Group.Session.Timeout`, and `Consumer.Group.Heartbeat.Interval` based on the new config fields, defaulting to 45s if unset.

Configuration and code improvements:

* Modified the signature of `setSaramaConfig` to accept the full `KafkaConfig`, allowing it to access new and existing fields for more dynamic configuration. [[1]](diffhunk://#diff-32f9e33a448ff914b06f549938fecfcad6ed71a09edf9788b75dbbc61e52262bL45-R45) [[2]](diffhunk://#diff-32f9e33a448ff914b06f549938fecfcad6ed71a09edf9788b75dbbc61e52262bL172-R197)
* Set a default `CloseTimeout` of 20 seconds in the Watermill router configuration for more graceful shutdowns.
* Added the `time` package import to support the new duration fields.